### PR TITLE
srv.nix: fix target missing toString function

### DIFF
--- a/records/srv.nix
+++ b/records/srv.nix
@@ -48,7 +48,7 @@ with lib;
       (toString priority)
       (toString weight)
       (toString port)
-      target
+      (toString target)
     ];
   };
 }


### PR DESCRIPTION
fixes following error:
```
error: A definition for option `dns.zones.nodes.de.nodes.example.nodes._tcp.nodes._imap.records.SRV.data."[definition 1-entry 4]"' is not of type `string'. Definition values:
- In `/nix/store/wg5jj2x91cwv2wr3qb8801jm3r3vjnnz-source/records/srv.nix':
   {
     __toString = <function>;
     _type = "domain";
     isAbsolute = true;
     isRelative = false;
   ...
````